### PR TITLE
Remove obsolete check in RSConvOriginalMSGDown constructor

### DIFF
--- a/torch_points3d/modules/RSConv/dense.py
+++ b/torch_points3d/modules/RSConv/dense.py
@@ -273,8 +273,6 @@ class RSConvOriginalMSGDown(BaseDenseConvolutionDown):
         **kwargs
     ):
         assert len(radii) == len(nsample)
-        if len(radii) != len(down_conv_nn):
-            log.warning("The down_conv_nn has a different size as radii. Make sure of have SharedRSConv")
         super(RSConvOriginalMSGDown, self).__init__(
             DenseFPSSampler(num_to_sample=npoint), DenseRadiusNeighbourFinder(radii, nsample), **kwargs
         )


### PR DESCRIPTION
Fixes #735 

I digged a bit deeper into it and realized that this check/warning is most likely obsolete, and probably only there because of copy-pasting `RSConvSharedMSGDown`. Here, the `down_conv_nn` argument (or the first sublist in the case of `first_layer`) is immediately unpacked into three values. Therefore, this list must always have a length of three, independent from the radii given.

Because of this I simply removed the check. It should become clear pretty quickly if the length is invalid, since then an exception would tell something like `too many values too unpack, expected 3...`.