### PR TITLE
Fix GridSampling3D fails when called with a cuda data tensor  without batch key

### DIFF
--- a/torch_points3d/core/data_transform/grid_transform.py
+++ b/torch_points3d/core/data_transform/grid_transform.py
@@ -116,7 +116,7 @@ class GridSampling3D:
 
         coords = torch.round((data.pos) / self._grid_size)
         if "batch" not in data:
-            cluster = grid_cluster(coords, torch.tensor([1, 1, 1], dtype=data.pos.dtype, device=data.pos.device))
+            cluster = grid_cluster(coords, torch.tensor([1, 1, 1], dtype=torch.float32, device=data.pos.device))
         else:
             cluster = voxel_grid(coords, data.batch, 1)
         cluster, unique_pos_indices = consecutive_cluster(cluster)

--- a/torch_points3d/core/data_transform/grid_transform.py
+++ b/torch_points3d/core/data_transform/grid_transform.py
@@ -116,7 +116,7 @@ class GridSampling3D:
 
         coords = torch.round((data.pos) / self._grid_size)
         if "batch" not in data:
-            cluster = grid_cluster(coords, torch.tensor([1, 1, 1]))
+            cluster = grid_cluster(coords, torch.tensor([1, 1, 1], dtype=data.pos.dtype, device=data.pos.device))
         else:
             cluster = voxel_grid(coords, data.batch, 1)
         cluster, unique_pos_indices = consecutive_cluster(cluster)
@@ -125,7 +125,7 @@ class GridSampling3D:
         if self._quantize_coords:
             data.coords = coords[unique_pos_indices].int()
 
-        data.grid_size = torch.tensor([self._grid_size])
+        data.grid_size = torch.tensor([self._grid_size], device=data.pos.device)
         return data
 
     def __call__(self, data):


### PR DESCRIPTION
Currently when GridSampling3D is called with a cuda data tensor which does not have a "batch" key, it fails with the below exception. This PR fixes it.

```
Exception has occurred: RuntimeError       (note: full exception trace is shown but execution is paused at: _run_module_as_main)
The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
  File "/home/firas/miniconda3/envs/legged_gym_crash_torch_121/lib/python3.8/site-packages/torch_cluster/grid.py", line 32, in grid_cluster
        cluster = grid_cluster(pos, size)
    """
    return torch.ops.torch_cluster.grid(pos, size, start, end)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
RuntimeError: size.device().is_cuda() INTERNAL ASSERT FAILED at "csrc/cuda/grid_cuda.cu":31, please report a bug to PyTorch. size must be CUDA tensor


  File "torch_points3d/core/data_transform/grid_transform.py", line 119, in _process
    cluster = grid_cluster(coords, torch.tensor([1, 1, 1]))
  File "torch_points3d/core/data_transform/grid_transform.py", line 135, in __call__
    data = self._process(data)
```
To test:
```
import torch
from torch_points3d.core.data_transform import GridSampling3D
from torch_geometric.data import Batch

data = torch.tensor([[0,0,0]], device='cuda')
data = Batch(pos=data)
pcd_to_grid = GridSampling3D(torch.tensor([0.2], device='cuda'))
pcd_to_grid(data)
```